### PR TITLE
Jenkins chart v3

### DIFF
--- a/deploy/01_jenkins-helm.yaml
+++ b/deploy/01_jenkins-helm.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     repository: https://charts.jenkins.io
     name: jenkins
-    version: '2.19.0'
+    version: '3.0.2'
   valuesFrom:
     - configMapKeyRef:
         name: jenkins-values

--- a/deploy/config/values.yaml
+++ b/deploy/config/values.yaml
@@ -1,4 +1,4 @@
-master:
+controller:
   numExecutors: 1
   executorMode: EXCLUSIVE
   secretsFilesSecret: jenkins-secrets

--- a/deploy/config/values.yaml
+++ b/deploy/config/values.yaml
@@ -1,10 +1,6 @@
 controller:
   numExecutors: 1
   executorMode: EXCLUSIVE
-  secretsFilesSecret: jenkins-secrets
-  containerEnv:
-  - name: SECRETS
-    value: /var/jenkins_secrets
   jenkinsAdminEmail: "admin@example.com"
   jenkinsUrl: "http://localhost:8080"
   JCasC:

--- a/deploy/config/values.yaml
+++ b/deploy/config/values.yaml
@@ -89,3 +89,21 @@ controller:
     - 'timestamper:latest'
 rbac:
   readSecrets: true
+persistence:
+  volumes:
+    - name: oidc-config
+      secret:
+        secretName: oidc-config
+  mounts:
+    - name: oidc-config
+      mountPath: /run/secrets/okta-client-id
+      subPath: okta-client-id
+      readOnly: true
+    - name: oidc-config
+      mountPath: /run/secrets/okta-client-secret
+      subPath: okta-client-secret
+      readOnly: true
+    - name: oidc-config
+      mountPath: /run/secrets/okta-org-name
+      subPath: okta-org-name
+      readOnly: true

--- a/deploy/config/values.yaml
+++ b/deploy/config/values.yaml
@@ -56,7 +56,7 @@ controller:
                 scm {
                   git {
                     remote {
-                      credentials('jenkins-easy')
+                      credentials('jenkins-easy-git')
                       url('git@github.com:oofnikj/jenkins-easy.git')
                     }
                   }
@@ -79,23 +79,13 @@ controller:
                   }
                 }
               }
-      credentials: |
-        credentials:
-          system:
-            domainCredentials:
-            - credentials:
-              - basicSSHUserPrivateKey:
-                  description: "jenkins-easy repo key"
-                  id: "jenkins-easy"
-                  privateKeySource:
-                    directEntry:
-                      privateKey: "${jenkins-easy.pem}"
-                  scope: GLOBAL
-                  username: "git"
   additionalPlugins:
     - 'authorize-project:1.3.0'
     - 'oic-auth:1.8'
     - 'matrix-auth:2.6.2'
     - 'job-dsl:1.77'
+    - 'kubernetes-credentials-provider:0.15'
     - 'ansicolor:latest'
     - 'timestamper:latest'
+rbac:
+  readSecrets: true

--- a/deploy/config/values.yaml
+++ b/deploy/config/values.yaml
@@ -56,7 +56,7 @@ controller:
                 scm {
                   git {
                     remote {
-                      credentials('jenkins-easy-git')
+                      credentials('jenkins-easy')
                       url('git@github.com:oofnikj/jenkins-easy.git')
                     }
                   }

--- a/deploy/config/values.yaml
+++ b/deploy/config/values.yaml
@@ -37,8 +37,8 @@ master:
               disableSslVerification: false
               escapeHatchEnabled: true
               escapeHatchGroup: "admin"
-              escapeHatchUsername: "${ADMIN_USER}"
-              escapeHatchSecret: "${ADMIN_PASSWORD}"
+              escapeHatchUsername: "${chart-admin-username}"
+              escapeHatchSecret: "${chart-admin-password}"
               logoutFromOpenidProvider: false
         security:
           queueItemAuthenticator:

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -14,9 +14,18 @@ configMapGenerator:
 secretGenerator:
 - name: jenkins-secrets
   envs:
-  - secrets/okta-oidc.env
+    - secrets/okta-oidc.env
+
+- name: jenkins-easy-git
+  literals:
+    - username=git
   files:
-  - secrets/jenkins-easy.pem
+    - privateKey=secrets/jenkins-easy.pem
+  options:
+    labels:
+      "jenkins.io/credentials-type": "basicSSHUserPrivateKey"
+    annotations:
+      "jenkins.io/credentials-description": "jenkins-easy repository SSH key"
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -12,11 +12,11 @@ configMapGenerator:
   - config/values.yaml
 
 secretGenerator:
-- name: jenkins-secrets
+- name: oidc-config
   envs:
     - secrets/okta-oidc.env
 
-- name: jenkins-easy-git
+- name: jenkins-easy
   literals:
     - username=git
   files:


### PR DESCRIPTION
* use `kubernetes-credentials-provider` to provision Git SSH key from secret
* split Okta config into separate secret
* switch from deprecated `secretsFilesSecret` to using `persistence.volumes` and `persistence.mounts`
* updated naming in v3 chart